### PR TITLE
chore(workflows): Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master, alpha, beta, next]
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Semantic Release
+      uses: cycjimmy/semantic-release-action@v2
+      with:
+        semantic_version: 17
+        extra_plugins: |
+          @semantic-release/changelog@5.0.1
+          @semantic-release/git@9.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,12 @@
+plugins:
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - "@semantic-release/changelog"
+  - "@semantic-release/npm"
+  - - "@semantic-release/git"
+    - assets:
+        - CHANGELOG.md
+        - package.json
+      message: "chore(release): version ${nextRelease.version}\n\n${nextRelease.notes}"
+  - "@semantic-release/github"
+  


### PR DESCRIPTION
Ajout du fichier déclenchant une release Github (avec création d'un tag) consécutivement à un `push` sur les branches `master`, `alpha`, `beta` et `next`.